### PR TITLE
Log the actual file name(if present) in error, instead of hard coding in DefaultAddressPicker.java

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -31,6 +31,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -214,12 +215,7 @@ class DefaultAddressPicker
         }
 
         if (interfacesConfig.isEnabled()) {
-            String configSource = config.getConfigurationFile() != null && config.getConfigurationFile().getName() != null
-                    && config.getConfigurationFile().exists() && config.getConfigurationFile().isFile() ?
-                    "the " + config.getConfigurationFile().getName() + " config file." : "the member configurations.";
-
-            String msg = "Hazelcast CANNOT start on this node. No matching network interface found.\n"
-                    + "Interface matching must be either disabled or updated in " + configSource;
+            String msg = errorMsgForMatchNetworkInterface();
             logger.severe(msg);
             throw new RuntimeException(msg);
         }
@@ -227,6 +223,15 @@ class DefaultAddressPicker
             logger.warning("Could not find a matching address to start with! Picking one of non-loopback addresses.");
         }
         return pickMatchingAddress(null);
+    }
+
+    private String errorMsgForMatchNetworkInterface() {
+        File file = config.getConfigurationFile();
+        String configSource = file != null && file.exists() && file.isFile()
+                ? "the " + file.getName() + " config file." : "the member configurations.";
+        String msg = "Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in " + configSource;
+        return msg;
     }
 
     private List<InterfaceDefinition> getInterfaces() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -215,7 +215,7 @@ class DefaultAddressPicker
         }
 
         if (interfacesConfig.isEnabled()) {
-            String msg = errorMsgForMatchNetworkInterface();
+            String msg = errorMsgForNoMatchingInterface();
             logger.severe(msg);
             throw new RuntimeException(msg);
         }
@@ -225,7 +225,7 @@ class DefaultAddressPicker
         return pickMatchingAddress(null);
     }
 
-    private String errorMsgForMatchNetworkInterface() {
+    private String errorMsgForNoMatchingInterface() {
         File file = config.getConfigurationFile();
         String configSource = file != null && file.exists() && file.isFile()
                 ? "the " + file.getName() + " config file." : "the member configurations.";

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -214,8 +214,12 @@ class DefaultAddressPicker
         }
 
         if (interfacesConfig.isEnabled()) {
+            String configSource = config.getConfigurationFile() != null && config.getConfigurationFile().getName() != null
+                    && config.getConfigurationFile().exists() && config.getConfigurationFile().isFile() ?
+                    "the " + config.getConfigurationFile().getName() + " config file." : "the member configurations.";
+
             String msg = "Hazelcast CANNOT start on this node. No matching network interface found.\n"
-                    + "Interface matching must be either disabled or updated in the hazelcast.xml config file.";
+                    + "Interface matching must be either disabled or updated in " + configSource;
             logger.severe(msg);
             throw new RuntimeException(msg);
         }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -38,8 +38,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -60,6 +62,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -78,6 +81,8 @@ public class DefaultAddressPickerTest {
     public final OverridePropertyRule ruleSysPropPreferIpv4Stack = set(PREFER_IPV4_STACK, "false");
     @Rule
     public final OverridePropertyRule ruleSysPropPreferIpv6Addresses = clear(PREFER_IPV6_ADDRESSES);
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private final ILogger logger = Logger.getLogger(AddressPicker.class);
     private final Config config = new Config();
@@ -363,7 +368,28 @@ public class DefaultAddressPickerTest {
         assertNotEquals(addressDefinition.hashCode(), addressDefinitionOtherPort.hashCode());
         assertNotEquals(addressDefinition.hashCode(), addressDefinitionOtherInetAddress.hashCode());
     }
-
+    @Test
+    public void testNotMatchingInterface_forCustomConfigFile() throws Exception {
+        Config config = new Config();
+        File cfgFile = tempFolder.newFile("custom_file.xml");
+        config.setConfigurationFile(cfgFile);
+        config.getNetworkConfig().getInterfaces().setEnabled(true);
+        config.getNetworkConfig().getInterfaces().addInterface("123.456.789");
+        RuntimeException thrown =  assertThrows(RuntimeException.class,
+                () -> HazelcastInstanceFactory.newHazelcastInstance(config));
+        assertTrue(thrown.getMessage().contentEquals("Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in the custom_file.xml config file."));
+    }
+    @Test
+    public void testNotMatchingInterface_forNoConfigFile() throws Exception {
+        Config config = new Config();
+        config.getNetworkConfig().getInterfaces().setEnabled(true);
+        config.getNetworkConfig().getInterfaces().addInterface("123.456.789");
+        RuntimeException thrown =  assertThrows(RuntimeException.class,
+                () -> HazelcastInstanceFactory.newHazelcastInstance(config));
+        assertTrue(thrown.getMessage().contentEquals("Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in the member configurations."));
+    }
     private static InetAddress findAnyNonLoopbackInterface() {
         return findNonLoopbackInterface(false, false);
     }


### PR DESCRIPTION
Log the actual file name(if present) in error, instead of hard coding.[HZ-2420]

[Fixes INSERT_LINK_TO_THE_ISSUE_HERE](https://hazelcast.atlassian.net/browse/HZ-2420)

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages): None

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
